### PR TITLE
Align the canonical CHNS capillary coupling with the strong form

### DIFF
--- a/report/chns.tex
+++ b/report/chns.tex
@@ -131,7 +131,7 @@ We considered the density, viscosity, and other quantities depending on the phas
 
 Boundary conditions were chosen such that most of the terms in the weak formulation zero out, and we are left with this simplistic version
 \begin{align*}
-    &\int_{\Omega} \density \velocity_t \cdot \test{\velocity} + \int_{\Omega} \density \left(\velocity \cdot \grad{\velocity} \right) \cdot \test{\velocity} + \viscosity \grad{\velocity} \mathbf{:} \grad{\test{\velocity}} - \int_{\Omega} \density \gravity \cdot \test{\velocity} + \phase \chempot \div{\test{\velocity}} + \int_{\Omega} \test{\pressure} \div{\velocity} - \pressure \div{\test{\velocity}} \\
+    &\int_{\Omega} \density \velocity_t \cdot \test{\velocity} + \int_{\Omega} \density \left(\velocity \cdot \grad{\velocity} \right) \cdot \test{\velocity} + \viscosity \grad{\velocity} \mathbf{:} \grad{\test{\velocity}} - \int_{\Omega} \density \gravity \cdot \test{\velocity} - \int_{\Omega} \phase \grad{\chempot} \cdot \test{\velocity} + \int_{\Omega} \test{\pressure} \div{\velocity} - \pressure \div{\test{\velocity}} \\
     & + \int_{\Omega} \phase_t \test{\phase} + \int_{\Omega} \left(\velocity \cdot \grad{\phase}\right) \test{\phase} + \int_{\Omega} M \grad{\chempot} \cdot \grad{\test{\phase}} + \int_{\Omega} \chempot \test{\chempot} - \varepsilon \sigma \grad{\phase} \cdot \grad{\test{\chempot}} - \frac{\sigma}{\varepsilon} \potential'(\phase) \test{\chempot} = 0
 \end{align*}
 

--- a/src/chns.py
+++ b/src/chns.py
@@ -281,7 +281,7 @@ class CahnHilliardNavierStokes:
             self.density(phi)*fd.inner(fd.dot(u, fd.nabla_grad(u)), v)
             + self.viscosity(phi)*fd.inner(fd.grad(u), fd.grad(v))
             - self.density(phi)*fd.dot(self.gravity, v)
-            - p*fd.div(v) - phi*mu*fd.div(v)
+            - phi*fd.inner(fd.grad(mu), v) - p*fd.div(v)
         )
 
         phase = lambda u, p, phi, mu: (

--- a/src/square.py
+++ b/src/square.py
@@ -11,6 +11,8 @@ import numpy as np
 from utils import refine_bary
 from functools import cached_property
 
+# Experimental many-bubble variant; the canonical capillary coupling lives in
+# `src/chns.py` and this file may intentionally diverge while ideas are tested.
 
 class CahnHilliardNavierStokes:
     def __init__(self):

--- a/src/stabilization.py
+++ b/src/stabilization.py
@@ -11,6 +11,8 @@ import numpy as np
 from utils import refine_bary
 from functools import cached_property
 
+# Experimental stabilization variant; the canonical capillary coupling lives in
+# `src/chns.py` and this file may intentionally diverge while ideas are tested.
 
 class CahnHilliardNavierStokes:
     def __init__(self):


### PR DESCRIPTION
## Summary
- change the canonical CHNS momentum residual in `src/chns.py` to use `-phi * grad(mu)` rather than `-phi * mu * div(v)`
- update `report/chns.tex` so the documented weak form matches the canonical implementation
- label the remaining solver variants that still diverge from the canonical capillary coupling as experimental

## Verification
- `python3 -m py_compile src/chns.py src/square.py src/stabilization.py`
- `./run_firedrake_container python3 src/chns.py --benchmark single_bubble --nx 10 --ny 30 --dt 1e-3 --steps 3 --output-every 3`

Closes #1