### PR TITLE
Initialize square.py chemical potential from phi0

### DIFF
--- a/src/square.py
+++ b/src/square.py
@@ -194,22 +194,21 @@ class CahnHilliardNavierStokes:
 
     @cached_property
     def initial_chempot(self):
-        return fd.Function(self.FunctionSpace[3])
-        # Time evolution seems to converge only when the chemical potential is correctly initialized
-        # phi = self.initial_phase
-        # mu = fd.Function(self.FunctionSpace[3])
-        # nu = fd.TestFunction(self.FunctionSpace[3])
+        # Time evolution seems to converge only when the chemical potential is correctly initialized.
+        phi = self.initial_phase
+        mu = fd.Function(self.FunctionSpace[3])
+        nu = fd.TestFunction(self.FunctionSpace[3])
 
-        # F = (
-        #     fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu))
-        #      - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
-        # ) * fd.dx
+        F = (
+            fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu))
+             - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
+        ) * fd.dx
 
-        # problem = fd.NonlinearVariationalProblem(F, mu)
-        # solver = fd.NonlinearVariationalSolver(problem)
-        # solver.solve()
+        problem = fd.NonlinearVariationalProblem(F, mu)
+        solver = fd.NonlinearVariationalSolver(problem)
+        solver.solve()
 
-        # return mu
+        return mu
 
     def initialize(self, *functions):
         initial_conditions = {


### PR DESCRIPTION
## Summary
- restore the consistent `mu0` solve in `src/square.py`
- remove the zero-valued shortcut so the many-bubble experiment starts from a chemical potential compatible with its initial phase field

## Verification
- `python3 -m py_compile src/square.py`
- `./run_firedrake_container python3 -c "import sys; sys.path.insert(0, 'src'); import square; model = square.CahnHilliardNavierStokes(); mu = model.initial_chempot; print(mu.dat.data_ro.min(), mu.dat.data_ro.max())"`

Closes #7