### PR TITLE
Use diffuse-interface bubble initialization in the experimental CHNS variants

### DIFF
--- a/src/parallel.py
+++ b/src/parallel.py
@@ -159,16 +159,15 @@ class CahnHilliardNavierStokes:
         centers = [[0.5, 1]]
         radius = 0.2
 
-        initial_phase = fd.Constant(0.)
+        interface_width = 0.5 * self.epsilon
+        initial_phase = 0.0
 
         for center in centers:
             diff = [(coordinates[i] - center[i])**2 for i in range(len(coordinates))]
-            distance = fd.sqrt(sum(diff))
+            distance = fd.sqrt(sum(diff) + 1e-12)
+            bubble = 0.5 * (1.0 - fd.tanh((distance - radius) / interface_width))
 
-            initial_phase = fd.max_value(
-                initial_phase,
-                fd.conditional(distance <= radius, 1. ,0.)
-            )
+            initial_phase = 1.0 - (1.0 - initial_phase) * (1.0 - bubble)
 
         return fd.Function(self.FunctionSpace[2]).interpolate(initial_phase)
 

--- a/src/square.py
+++ b/src/square.py
@@ -179,16 +179,15 @@ class CahnHilliardNavierStokes:
         # centers = np.array([[0.4, 0.3], [0.6, 0.8]])
         # radius = 0.2
 
-        initial_phase = fd.Constant(0.)
+        interface_width = 0.5 * self.epsilon
+        initial_phase = 0.0
 
         for center in centers:
             diff = [(coordinates[i] - center[i])**2 for i in range(len(coordinates))]
-            distance = fd.sqrt(sum(diff))
+            distance = fd.sqrt(sum(diff) + 1e-12)
+            bubble = 0.5 * (1.0 - fd.tanh((distance - radius) / interface_width))
 
-            initial_phase = fd.max_value(
-                initial_phase,
-                fd.conditional(distance <= radius, 1. ,0.)
-            )
+            initial_phase = 1.0 - (1.0 - initial_phase) * (1.0 - bubble)
 
         return fd.Function(self.FunctionSpace[2]).interpolate(initial_phase)
 

--- a/src/stabilization.py
+++ b/src/stabilization.py
@@ -180,16 +180,15 @@ class CahnHilliardNavierStokes:
         centers = np.array([[0.4, 0.3], [0.6, 0.8]])
         radius = 0.2
 
-        initial_phase = fd.Constant(0.)
+        interface_width = 0.5 * self.epsilon
+        initial_phase = 0.0
 
         for center in centers:
             diff = [(coordinates[i] - center[i])**2 for i in range(len(coordinates))]
-            distance = fd.sqrt(sum(diff))
+            distance = fd.sqrt(sum(diff) + 1e-12)
+            bubble = 0.5 * (1.0 - fd.tanh((distance - radius) / interface_width))
 
-            initial_phase = fd.max_value(
-                initial_phase,
-                fd.conditional(distance <= radius, 1. ,0.)
-            )
+            initial_phase = 1.0 - (1.0 - initial_phase) * (1.0 - bubble)
 
         return fd.Function(self.FunctionSpace[2]).interpolate(initial_phase)
 


### PR DESCRIPTION
## Summary
- replace step-function bubble indicators with smooth diffuse-interface profiles in `src/parallel.py`, `src/square.py`, and `src/stabilization.py`
- combine overlapping bubbles with a smooth bounded union so the phase field stays in `[0, 1]`
- keep the canonical `src/chns.py` benchmark as the reference implementation while bringing the experimental variants closer to the same initialization model

## Verification
- `python3 -m py_compile src/parallel.py src/square.py src/stabilization.py`
- `./run_firedrake_container python3 -c "import sys; sys.path.insert(0, 'src'); import parallel; model = parallel.CahnHilliardNavierStokes(); phi = model.initial_phase; print(phi.dat.data_ro.min(), phi.dat.data_ro.max())"`
- `./run_firedrake_container python3 -c "import sys; sys.path.insert(0, 'src'); import stabilization; model = stabilization.CahnHilliardNavierStokes(); phi = model.initial_phase; print(phi.dat.data_ro.min(), phi.dat.data_ro.max())"`

Closes #6