### PR TITLE
Clarify the canonical CHNS velocity-pressure pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Self-propelled droplet
 
-Possibly a simulation of a self-propelling droplet governed by the Cahn-Hilliard-Navier-Stokes equations on a torus, i.e. a two-dimensional structure. To conform with the CHNS equations, we shall use the Scott-Vogelius pair, with some adaptive mesh refinement. The droplet will be self-propelled by a gradient in the chemical potential, which will be implemented as a source term in the Navier-Stokes equations. The droplet will be confined to a torus, which will be implemented either as a periodic boundary condition or as a three-dimensional object.
+This repo contains Firedrake experiments for Cahn-Hilliard and Cahn-Hilliard-Navier-Stokes simulations. The current canonical CHNS benchmark lives in `src/chns.py` and uses a Taylor-Hood velocity-pressure pair on a rectangle for rising-bubble studies. Other solver files explore pressure-robust, barycentrically refined, parallel, and many-bubble variants.
 
 <p align="center">
   <img width="45%" src="https://github.com/jk-dot/chns/blob/main/report/graphics/bublina.gif" alt="bublina">
@@ -11,4 +11,4 @@ Possibly a simulation of a self-propelling droplet governed by the Cahn-Hilliard
 
 # TODO
 - [ ] error estimation and mesh adaptivity
-- [x] pressure-robust methods
+- [ ] pressure-robust discretization study

--- a/src/chns.py
+++ b/src/chns.py
@@ -297,7 +297,8 @@ class CahnHilliardNavierStokes:
             + q * fd.div(u) + fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu)) - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
         ) * fd.dx() # fd.dx(degree=6)
 
-        # possibly not needed since using pressure-robust method
+        # Old stabilization notes kept for reference while comparing
+        # alternative incompressibility treatments.
         # R space does not even work with this setting, so....
         # F += (p * s + r * q) * fd.dx # pressure stabilization
         # F += 0.1 * fd.div(u) * fd.div(v) * fd.dx # stabilization ?
@@ -364,13 +365,6 @@ class CahnHilliardNavierStokes:
                 pbar.set_postfix_str(
                     f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
                 )
-<<<<<<< HEAD
-
-        return history
-
-=======
->>>>>>> c7d401a (feat(chns): add bubble benchmarks and diagnostics)
-
         return history
 if __name__ == '__main__':
     model = CahnHilliardNavierStokes(

--- a/src/parallel.py
+++ b/src/parallel.py
@@ -80,7 +80,7 @@ class CahnHilliardNavierStokes:
 
     @cached_property
     def FunctionSpace(self):
-        # Scott-Vogelius pressure-robust
+        # Experimental DG-pressure variant; this is not the canonical solver.
         k = 2
         V = fd.VectorFunctionSpace(self.mesh, "CG", k)  # Velocity
         P = fd.FunctionSpace(self.mesh, "DG", k-1)      # Pressure

--- a/src/square.py
+++ b/src/square.py
@@ -99,7 +99,8 @@ class CahnHilliardNavierStokes:
 
     @cached_property
     def FunctionSpace(self):
-        # Scott-Vogelius pressure-robust
+        # Experimental many-bubble variant using DG pressure on a barycentrically
+        # refined mesh.
         k = 2
         V = fd.VectorFunctionSpace(self.mesh, "CG", k)  # Velocity
         P = fd.FunctionSpace(self.mesh, "DG", k-1)      # Pressure
@@ -263,7 +264,8 @@ class CahnHilliardNavierStokes:
             + q * fd.div(u) + fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu)) - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
         ) * fd.dx
 
-        # possibly not needed since using pressure-robust method
+        # Old stabilization notes kept for reference while comparing
+        # alternative incompressibility treatments.
         # R space does not even work with this setting, so....
         # F += (p * s + r * q) * fd.dx # pressure stabilization
 

--- a/src/stabilization.py
+++ b/src/stabilization.py
@@ -99,7 +99,8 @@ class CahnHilliardNavierStokes:
 
     @cached_property
     def FunctionSpace(self):
-        # Scott-Vogelius pressure-robust
+        # Experimental Taylor-Hood-like variant with an extra scalar
+        # pressure-stabilization field.
         k = 2
         V = fd.VectorFunctionSpace(self.mesh, "CG", k)  # Velocity
         P = fd.FunctionSpace(self.mesh, "CG", k-1)      # Pressure
@@ -266,7 +267,8 @@ class CahnHilliardNavierStokes:
             + q * fd.div(u) + fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu)) - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
         ) * fd.dx
 
-        # possibly not needed since using pressure-robust method
+        # Old stabilization notes kept for reference while comparing
+        # alternative incompressibility treatments.
         # R space does not even work with this setting, so....
         F += (p * s + r * q) * fd.dx # pressure stabilization
 


### PR DESCRIPTION
## Summary
- document `src/chns.py` as the canonical Taylor-Hood CHNS solver instead of implying Scott-Vogelius everywhere
- relabel `src/parallel.py`, `src/square.py`, and `src/stabilization.py` comments so they are clearly experimental alternatives
- update the README so the repo description matches the actual benchmark solver in use

## Verification
- `python3 -m py_compile src/chns.py src/parallel.py src/square.py src/stabilization.py`
- searched the repo for stale `Scott-Vogelius` / `pressure-robust` claims and limited the remaining references to intentional experimental context

Closes #3