### PR TITLE
Default the CHNS solvers to backward Euler while stabilization is in progress

### DIFF
--- a/src/chns.py
+++ b/src/chns.py
@@ -28,7 +28,7 @@ class CahnHilliardNavierStokes:
         self.output_every = output_every
 
         self.file = fd.VTKFile(f"output/chns-{benchmark}.pvd")
-        self.theta = 1.0
+        self.theta = 1.0  # Backward Euler default for the canonical benchmark.
 
         self.rho1, self.rho2 = 10, 1
         self.nu1 = self.nu2 = 1 # paper says should be the same
@@ -364,13 +364,6 @@ class CahnHilliardNavierStokes:
                 pbar.set_postfix_str(
                     f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
                 )
-<<<<<<< HEAD
-
-        return history
-
-=======
->>>>>>> c7d401a (feat(chns): add bubble benchmarks and diagnostics)
-
         return history
 if __name__ == '__main__':
     model = CahnHilliardNavierStokes(

--- a/src/parallel.py
+++ b/src/parallel.py
@@ -11,7 +11,7 @@ from functools import cached_property
 class CahnHilliardNavierStokes:
     def __init__(self):
         self.file = VTKFile("output/parallel.pvd", "w")
-        self.theta = 0.5  # Crank-Nicolson
+        self.theta = 1.0  # Backward Euler while the CHNS formulation is still being stabilized.
 
         # Physical parameters
         self.rho1, self.rho2 = 1000.0, 1100.0  # kg/m^3


### PR DESCRIPTION
## Summary
- keep the canonical `src/chns.py` benchmark explicitly on backward Euler
- switch `src/parallel.py` from Crank-Nicolson to backward Euler while the CHNS formulation is still being stabilized
- remove the stale merge marker at the end of `src/chns.py` so branches cut from `dev` remain syntax-checkable

## Verification
- `python3 -m py_compile src/chns.py src/parallel.py`
- confirmed there are no remaining Python merge markers in this branch

Closes #5