### PR TITLE
Use conservative variable-density momentum transport in the canonical CHNS solver

### DIFF
--- a/report/chns.tex
+++ b/report/chns.tex
@@ -111,7 +111,7 @@
 
 Governing equations
 \begin{align*}
- \density \left(\velocity_t + \velocity \cdot \grad{\velocity}\right) - \viscosity \Delta{\velocity} + \grad{\pressure} &= \density \gravity - \phase \grad{\chempot}, \\
+ \partial_t \left(\density \velocity\right) + \div\left(\density \velocity \otimes \velocity\right) - \viscosity \Delta{\velocity} + \grad{\pressure} &= \density \gravity - \phase \grad{\chempot}, \\
     \div{\velocity} &= 0, \\
  \phase_t + \velocity \cdot \grad{\phase} &= \div{\left(\mobility \grad{\chempot}\right)}, \\
  \chempot &= -\varepsilon \sigma \Delta \phase + \frac{\sigma}{\varepsilon} \potential'(\phase).
@@ -129,16 +129,16 @@ We considered the density, viscosity, and other quantities depending on the phas
                 \end{cases}
 \end{equation*}
 
-Boundary conditions were chosen such that most of the terms in the weak formulation zero out, and we are left with this simplistic version
+Boundary conditions were chosen such that most of the terms in the weak formulation zero out, and we are left with this conservative transport variant
 \begin{align*}
-    &\int_{\Omega} \density \velocity_t \cdot \test{\velocity} + \int_{\Omega} \density \left(\velocity \cdot \grad{\velocity} \right) \cdot \test{\velocity} + \viscosity \grad{\velocity} \mathbf{:} \grad{\test{\velocity}} - \int_{\Omega} \density \gravity \cdot \test{\velocity} - \int_{\Omega} \phase \grad{\chempot} \cdot \test{\velocity} + \int_{\Omega} \test{\pressure} \div{\velocity} - \pressure \div{\test{\velocity}} \\
+    &\int_{\Omega} \partial_t \left(\density \velocity\right) \cdot \test{\velocity} + \int_{\Omega} \div\left(\density \velocity \otimes \velocity\right) \cdot \test{\velocity} + \viscosity \grad{\velocity} \mathbf{:} \grad{\test{\velocity}} - \int_{\Omega} \density \gravity \cdot \test{\velocity} - \int_{\Omega} \phase \grad{\chempot} \cdot \test{\velocity} + \int_{\Omega} \test{\pressure} \div{\velocity} - \pressure \div{\test{\velocity}} \\
     & + \int_{\Omega} \phase_t \test{\phase} + \int_{\Omega} \left(\velocity \cdot \grad{\phase}\right) \test{\phase} + \int_{\Omega} M \grad{\chempot} \cdot \grad{\test{\phase}} + \int_{\Omega} \chempot \test{\chempot} - \varepsilon \sigma \grad{\phase} \cdot \grad{\test{\chempot}} - \frac{\sigma}{\varepsilon} \potential'(\phase) \test{\chempot} = 0
 \end{align*}
 
 
 For stability reasons, this system needs to be computed on a mesh with high detail and some backward method, like the backward Euler. The resulting functional renders
 \begin{align*}
-    \int_{\Omega} \frac{\phase_{i + 1} - \phase_i}{\dd{t}} \test{\phase} &+ \int_{\Omega} \left(\theta \density(\phase_{i + 1}) + (1 - \theta) \density(\phase_i)\right) \frac{\velocity_{i+1} - \velocity_i}{\dd{t}} \cdot \test{\velocity} \\
+    \int_{\Omega} \frac{\phase_{i + 1} - \phase_i}{\dd{t}} \test{\phase} &+ \int_{\Omega} \frac{\density(\phase_{i + 1}) \velocity_{i+1} - \density(\phase_i) \velocity_i}{\dd{t}} \cdot \test{\velocity} \\
     &+ \theta\left(F_{\text{phase}} + F_{\text{Navier-Stokes}}\right)\left(\velocity_{i+1}, \pressure_{i+1}, \phase_{i+1}, {\chempot}_{i+1}\right)\\
     &+ (1 - \theta)\left(F_{\text{phase}} + F_{\text{Navier-Stokes}}\right)\left(\velocity_{i}, \pressure_{i}, \phase_{i}, {\chempot}_{i}\right) \\
     &+ \int_{\Omega} {\test{\pressure}} \div{\velocity} + \int_{\Omega} \chempot \test{\chempot} - \varepsilon \sigma \grad{\phase} \cdot \grad{\test{\chempot}} - \frac{\sigma}{\varepsilon} \potential'(\phase) \test{\chempot} = 0

--- a/src/chns.py
+++ b/src/chns.py
@@ -278,7 +278,7 @@ class CahnHilliardNavierStokes:
         total_time = n * dt
 
         momentum = lambda u, p, phi, mu: (
-            self.density(phi)*fd.inner(fd.dot(u, fd.nabla_grad(u)), v)
+            fd.inner(fd.div(fd.outer(self.density(phi) * u, u)), v)
             + self.viscosity(phi)*fd.inner(fd.grad(u), fd.grad(v))
             - self.density(phi)*fd.dot(self.gravity, v)
             - phi*fd.inner(fd.grad(mu), v) - p*fd.div(v)
@@ -291,7 +291,7 @@ class CahnHilliardNavierStokes:
 
         F = (
             fd.inner((phi - phi_) / dt, psi) 
-            + (self.theta*self.density(phi) + (1 - self.theta) * self.density(phi_)) * fd.inner((u - u_) / dt, v)
+            + fd.inner((self.density(phi) * u - self.density(phi_) * u_) / dt, v)
             + self.theta * momentum(u, p, phi, mu) + self.theta * phase(u, p, phi, mu)
             + (1 - self.theta) * momentum(u_, p_, phi_, mu_) + (1 - self.theta) * phase(u_, p_, phi_, mu_)
             + q * fd.div(u) + fd.inner(mu, nu) - self.epsilon*self.sigma*fd.inner(fd.grad(phi), fd.grad(nu)) - self.sigma/self.epsilon*fd.inner(self.potential_derivative(phi), nu)
@@ -364,13 +364,6 @@ class CahnHilliardNavierStokes:
                 pbar.set_postfix_str(
                     f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
                 )
-<<<<<<< HEAD
-
-        return history
-
-=======
->>>>>>> c7d401a (feat(chns): add bubble benchmarks and diagnostics)
-
         return history
 if __name__ == '__main__':
     model = CahnHilliardNavierStokes(


### PR DESCRIPTION
## Summary
- switch the canonical CHNS benchmark in `src/chns.py` from `rho(phi) * u_t + rho(phi) * (u · grad u)` to a conservative momentum-density form
- update the report equations and discrete functional in `report/chns.tex` so the writeup matches the implemented canonical solver
- remove the stale merge marker still present in `src/chns.py` on branches cut from `dev`

## Verification
- `python3 -m py_compile src/chns.py`
- no runtime simulation was executed in this branch, per current workflow request

Closes #2