### PR TITLE
Align the local tooling entrypoints with the Firedrake helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,46 @@
 SHELL := /bin/zsh
 
+.PHONY: clean build run run-gui run-ch run-chns run-chns-two run-parallel help
+
 clean:
 	@setopt nullglob; \
 	for dir in output; do \
 		rm -f $$dir/*.{out,log,fls,blg,fdb_latexmk,aux,bbl,bcf,run.xml,synctex.gz}; \
 	done
 
-# Variables
-IMAGE_NAME = firedrake-zsh
-CONTAINER_NAME = firedrake-container
-SHARED_DIR = $(shell pwd)/shared
+FIREDRAKE_IMAGE = firedrakeproject/firedrake:2025.4.2
 
-# Build the Docker image
 build:
-	docker build -t $(IMAGE_NAME) .
+	docker pull $(FIREDRAKE_IMAGE)
 
-# Run the Docker container interactively
 run:
-	docker run -it --rm \
-		--name $(CONTAINER_NAME) \
-		-v $(SHARED_DIR):/home/firedrake/shared \
-		$(IMAGE_NAME)
+	bash ./run_firedrake_container bash
 
-# Run the Docker container with X11 forwarding (for GUI applications)
 run-gui:
-	docker run -it --rm \
-		--name $(CONTAINER_NAME) \
-		-v $(SHARED_DIR):/home/firedrake/shared \
-		-e DISPLAY=$(DISPLAY) \
-		-v /tmp/.X11-unix:/tmp/.X11-unix \
-		$(IMAGE_NAME)
+	bash ./run_firedrake_container bash
 
-# Help message
+run-ch:
+	bash ./run_firedrake_container python3 src/ch.py
+
+run-chns:
+	bash ./run_firedrake_container python3 src/chns.py --benchmark single_bubble
+
+run-chns-two:
+	bash ./run_firedrake_container python3 src/chns.py --benchmark two_bubbles
+
+run-parallel:
+	bash ./run_firedrake_container mpiexec -n 2 python3 src/parallel.py
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build      Build the Docker image"
-	@echo "  run        Run the Docker container interactively"
-	@echo "  run-gui    Run the Docker container with X11 forwarding (for GUI applications)"
-	@echo "  clean      Remove the Docker image"
-	@echo "  help       Show this help message"
+	@echo "  build         Pull the supported Firedrake image"
+	@echo "  run           Open an interactive Firedrake shell"
+	@echo "  run-gui       Alias for 'run' (the helper already wires X11 mounts)"
+	@echo "  run-ch        Run the periodic Cahn-Hilliard benchmark"
+	@echo "  run-chns      Run the canonical single-bubble CHNS benchmark"
+	@echo "  run-chns-two  Run the canonical two-bubble CHNS benchmark"
+	@echo "  run-parallel  Run the experimental MPI CHNS variant"
+	@echo "  clean         Remove LaTeX auxiliary files from output/"
+	@echo "  help          Show this help message"

--- a/run_firedrake_container
+++ b/run_firedrake_container
@@ -36,28 +36,17 @@ DOCKER_RUN_CMD+=(
 
 # Compose usage message
 read -r -d '' USAGE <<EOF || true
-# Advise user to install a nice debugger
-echo "${BLUE}Run 'pip install pdbpp' to get a nice debugger${RESET}"
-echo "${BLUE}${RESET}"
-echo "${BLUE}Run 'pip install git+https://bitbucket.org/pefarrell/defcon.git' to obtain defcon${RESET}"
-echo "${BLUE}${RESET}"
-echo "${BLUE}To use defcon GUI run additionally:${RESET}"
-echo "${BLUE}  sudo apt update${RESET}"
-echo "${BLUE}  sudo apt install -y --no-install-recommends dvipng texlive-latex-extra texlive-fonts-recommended cm-super libxcb-xinerama0-dev libxcb-xkb-dev libxcb-shape0-dev libxcb-render-util0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-icccm4-dev libxcb-util-dev libxcb-keysyms1-dev libxkbcommon-x11-dev libgl1${RESET}"
-echo "${BLUE}  pip install PyQt5 tikzplotlib${RESET}"
-echo "${BLUE}${RESET}"
-echo "${BLUE}Then you can do:${RESET}"
-echo "${BLUE}  cd defcon/scripts/${RESET}"
-echo "${BLUE}  python3 -m defcon gui -p bratu_gelfand.py &${RESET}"
-echo "${BLUE}  mpiexec -n 2 python3 bratu_gelfand.py${RESET}"
+echo "${BLUE}Repo mounted at ${CONTAINER_MOUNT_POINT}${RESET}"
 echo "${BLUE}${RESET}"
 echo "${BLUE}If you get error messages such as 'No protocol specified'${RESET}"
 echo "${BLUE}or 'Error: Can't open display: :0.0' try running on the host:${RESET}"
 echo "${BLUE}  xhost +local:docker${RESET}"
 echo "${BLUE}${RESET}"
 echo "${BLUE}Quick start:${RESET}"
-echo "${BLUE}  cd pressure-robust${RESET}"
-echo "${BLUE}  python3 stokes.py${RESET}"
+echo "${BLUE}  python3 src/ch.py${RESET}"
+echo "${BLUE}  python3 src/chns.py --benchmark single_bubble${RESET}"
+echo "${BLUE}  python3 src/chns.py --benchmark two_bubbles${RESET}"
+echo "${BLUE}  mpiexec -n 2 python3 src/parallel.py${RESET}"
 echo "${BLUE}${RESET}"
 EOF
 


### PR DESCRIPTION
## Summary
- replace the stale root-Dockerfile `Makefile` flow with helper-based targets that match the supported Firedrake workflow
- add direct `make run-ch`, `make run-chns`, `make run-chns-two`, and `make run-parallel` shortcuts
- update `run_firedrake_container` so its usage banner shows this repo's actual quick-start commands instead of unrelated `defcon` / `pressure-robust` text

## Verification
- `bash -n run_firedrake_container`
- `make help`
- no simulation was executed in this branch, per current workflow request

Closes #12