### PR TITLE
Align the CH report figure captions with the generated snapshots

### DIFF
--- a/report/ch.tex
+++ b/report/ch.tex
@@ -114,25 +114,25 @@ Below we present the snapshots from the time evolution on the square as well as 
     \centering
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t0.5.pdf}
-        \caption*{$t = 0$}
+        \caption*{$t = 0.5$}
         \label{fig:image1}
     \end{subfigure}
     \hfill
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t1.0.pdf}
-        \caption*{$t = 0.05$}
+        \caption*{$t = 1.0$}
         \label{fig:image2}
     \end{subfigure}
     \hfill
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t1.5.pdf}
-        \caption*{$t = 0.1$}
+        \caption*{$t = 1.5$}
         \label{fig:image3}
     \end{subfigure}
     \hfill
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t2.pdf}
-        \caption*{$t = 0.2$}
+        \caption*{$t = 2.0$}
         \label{fig:image4}
     \end{subfigure}
     
@@ -140,26 +140,20 @@ Below we present the snapshots from the time evolution on the square as well as 
   
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t2.5.pdf}
-        \caption*{$t = 0.3$}
+        \caption*{$t = 2.5$}
         \label{fig:image5}
     \end{subfigure}
     \hfill
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t3.pdf}
-        \caption*{$t = 0.4$}
+        \caption*{$t = 3.0$}
         \label{fig:image6}
     \end{subfigure}
     \hfill
     \begin{subfigure}[b]{0.2\textwidth}
         \includegraphics[width=\textwidth]{ch-t4.pdf}
-        \caption*{$t = 0.5$}
+        \caption*{$t = 4.0$}
         \label{fig:image7}
-    \end{subfigure}
-    \hfill
-    \begin{subfigure}[b]{0.2\textwidth}
-        \includegraphics[width=\textwidth]{ch-t4.pdf}
-        \caption*{$t = 1$}
-        \label{fig:image8}
     \end{subfigure}
     
     \caption{Snapshots from time evolution of the Cahn-Hilliard model on a unit square with periodic boundary conditions.}


### PR DESCRIPTION
## Summary
- update `report/ch.tex` so each CH snapshot caption matches the actual generated filename/time
- remove the duplicated final subfigure that reused `ch-t4.pdf` with a conflicting caption

## Verification
- checked `report/ch.tex` against the filenames present in `report/graphics/`
- no simulation was executed in this branch, per current workflow request

Closes #15