### PR TITLE
Separate generated solver outputs from tracked report assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
-output/*.pdf filter=lfs diff=lfs merge=lfs -text
+# Tracked compiled report deliverables.
+output/ch.pdf filter=lfs diff=lfs merge=lfs -text
+output/chns.pdf filter=lfs diff=lfs merge=lfs -text
+
+# Tracked report graphics and animations.
 report/graphics/* filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-
-# output/
 __pycache__/
-# report/graphics/
+.cache/
 
+# Keep only the tracked compiled report PDFs in output/.
+output/*
+!output/ch.pdf
+!output/chns.pdf
 
 .bash_history
 .python_history


### PR DESCRIPTION
## Summary
- ignore generated solver outputs under `output/` while keeping the tracked `output/ch.pdf` and `output/chns.pdf`
- ignore the repo-local Firedrake cache directory
- tighten `.gitattributes` so LFS applies explicitly to the tracked report PDFs and tracked report graphics

## Verification
- checked `.gitignore` and `.gitattributes` against the current tracked files in `output/` and `report/graphics/`
- no simulation was executed in this branch, per current workflow request

Closes #13