### PR TITLE
Separate the canonical CHNS solver from the experimental variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Useful CHNS overrides:
 
 ## Other Solver Files
 
+- Only `src/chns.py` should be treated as the canonical CHNS solver for new numerical work.
 - `src/ch.py`: periodic CH reference problem.
 - `src/chns.py`: canonical CHNS rising-bubble benchmark.
 - `src/parallel.py`: experimental parallel CHNS variant.

--- a/src/parallel.py
+++ b/src/parallel.py
@@ -8,6 +8,9 @@ import numpy as np
 from utils import refine_bary
 from functools import cached_property
 
+# Experimental MPI-oriented CHNS variant; use `src/chns.py` as the canonical
+# solver when making formulation or benchmark changes.
+
 class CahnHilliardNavierStokes:
     def __init__(self):
         self.file = VTKFile("output/parallel.pvd", "w")

--- a/src/square.py
+++ b/src/square.py
@@ -16,7 +16,7 @@ from functools import cached_property
 
 class CahnHilliardNavierStokes:
     def __init__(self):
-        self.file = fd.VTKFile("output/bubbles.pvd")
+        self.file = fd.VTKFile("output/square-many_bubbles.pvd")
         self.theta = 1 # time-evolution param
 
         self.rho1, self.rho2 = 10, 1

--- a/src/stabilization.py
+++ b/src/stabilization.py
@@ -16,7 +16,7 @@ from functools import cached_property
 
 class CahnHilliardNavierStokes:
     def __init__(self):
-        self.file = fd.VTKFile("output/chns.pvd")
+        self.file = fd.VTKFile("output/stabilization.pvd")
         self.theta = 1 # time-evolution param
 
         self.rho1, self.rho2 = 10, 1


### PR DESCRIPTION
## Summary
- document `src/chns.py` as the canonical CHNS solver for new numerical work
- label `src/parallel.py` more explicitly as an experimental MPI-oriented variant
- rename the experimental VTK outputs so `src/square.py` and `src/stabilization.py` no longer collide with canonical filenames

## Verification
- `python3 -m py_compile src/parallel.py src/square.py src/stabilization.py`
- checked the output filenames in the updated source files to ensure the experimental variants no longer write `output/chns.pvd`
- no simulation was executed in this branch, per current workflow request

Closes #11