### PR TITLE
Add a CHNS mesh/timestep study harness

### DIFF
--- a/src/chns.py
+++ b/src/chns.py
@@ -1,15 +1,23 @@
 import argparse
 import sys
 
-CLI_PARSER = argparse.ArgumentParser(description="Run the canonical CHNS rising-bubble benchmark.")
-CLI_PARSER.add_argument("--benchmark", choices=("single_bubble", "two_bubbles"), default="single_bubble")
-CLI_PARSER.add_argument("--nx", type=int, default=20)
-CLI_PARSER.add_argument("--ny", type=int, default=60)
-CLI_PARSER.add_argument("--dt", type=float, default=1e-3)
-CLI_PARSER.add_argument("--steps", type=int, default=1000)
-CLI_PARSER.add_argument("--output-every", type=int, default=20)
-CLI_ARGS, REMAINING_ARGV = CLI_PARSER.parse_known_args()
-sys.argv = [sys.argv[0], *REMAINING_ARGV]
+def _parse_main_args(argv):
+    parser = argparse.ArgumentParser(description="Run the canonical CHNS rising-bubble benchmark.")
+    parser.add_argument("--benchmark", choices=("single_bubble", "two_bubbles"), default="single_bubble")
+    parser.add_argument("--nx", type=int, default=20)
+    parser.add_argument("--ny", type=int, default=60)
+    parser.add_argument("--dt", type=float, default=1e-3)
+    parser.add_argument("--steps", type=int, default=1000)
+    parser.add_argument("--output-every", type=int, default=20)
+    parser.add_argument("--no-output", action="store_true")
+    return parser.parse_known_args(argv)
+
+
+if __name__ == '__main__':
+    CLI_ARGS, REMAINING_ARGV = _parse_main_args(sys.argv[1:])
+    sys.argv = [sys.argv[0], *REMAINING_ARGV]
+else:
+    CLI_ARGS = None
 
 from tqdm import tqdm
 import firedrake as fd
@@ -19,15 +27,16 @@ from functools import cached_property
 
 
 class CahnHilliardNavierStokes:
-    def __init__(self, benchmark="single_bubble", nx=20, ny=60, dt=1e-3, steps=1000, output_every=20):
+    def __init__(self, benchmark="single_bubble", nx=20, ny=60, dt=1e-3, steps=1000, output_every=20, write_output=True):
         self.benchmark = benchmark
         self.nx = nx
         self.ny = ny
         self.dt = dt
         self.n_steps = steps
         self.output_every = output_every
+        self.write_output = write_output
 
-        self.file = fd.VTKFile(f"output/chns-{benchmark}.pvd")
+        self.file = fd.VTKFile(f"output/chns-{benchmark}.pvd") if write_output else None
         self.theta = 1.0  # Backward Euler default for the canonical benchmark.
 
         self.rho1, self.rho2 = 10, 1
@@ -85,6 +94,7 @@ class CahnHilliardNavierStokes:
                 - Mobility: m0 = {self.m0}
                 - σ = {self.sigma}, ε = {self.epsilon}
                 - dt = {self.dt}, steps = {self.n_steps}
+                - write_output = {self.write_output}
             · Mesh:
                 - Cells: {self.mesh.num_cells()}
                 - Vertices: {self.mesh.num_vertices()}
@@ -319,7 +329,8 @@ class CahnHilliardNavierStokes:
         history = []
         velocity_fn, _, phase_fn, _ = w.subfunctions
         initial_diagnostics = self.collect_diagnostics(velocity_fn, phase_fn)
-        self.file.write(*w.subfunctions, time=0.0)
+        if self.file is not None:
+            self.file.write(*w.subfunctions, time=0.0)
         history.append({"step": 0, "time": 0.0, "iterations": 0, "reason": 0, **initial_diagnostics})
 
         with tqdm(
@@ -335,7 +346,7 @@ class CahnHilliardNavierStokes:
                 velocity_fn, _, phase_fn, _ = w.subfunctions
                 diagnostics = self.collect_diagnostics(velocity_fn, phase_fn)
 
-                if step % self.output_every == 0:
+                if self.file is not None and step % self.output_every == 0:
                     self.file.write(*w.subfunctions, time=t)
 
                 snes = solver.snes
@@ -374,6 +385,7 @@ if __name__ == '__main__':
         dt=CLI_ARGS.dt,
         steps=CLI_ARGS.steps,
         output_every=CLI_ARGS.output_every,
+        write_output=not CLI_ARGS.no_output,
     )
 
     print(model)

--- a/src/chns_study.py
+++ b/src/chns_study.py
@@ -1,0 +1,91 @@
+import argparse
+import json
+from itertools import product
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run a mesh/timestep sweep for the canonical CHNS rising-bubble benchmark."
+    )
+    parser.add_argument("--benchmark", choices=("single_bubble", "two_bubbles"), default="single_bubble")
+    parser.add_argument(
+        "--meshes",
+        nargs="+",
+        default=("20x60", "30x90", "40x120"),
+        help="Mesh sizes as NXxNY, e.g. 20x60 30x90",
+    )
+    parser.add_argument("--dts", nargs="+", type=float, default=(1e-3, 5e-4, 2.5e-4))
+    parser.add_argument("--steps", type=int, default=1000)
+    parser.add_argument("--output-every", type=int, default=20)
+    parser.add_argument("--write-output", action="store_true")
+    parser.add_argument(
+        "--summary-json",
+        default="output/chns-study-summary.json",
+        help="Where to write the study summary JSON",
+    )
+    return parser.parse_args()
+
+
+def parse_mesh(spec):
+    nx_str, ny_str = spec.lower().split("x", 1)
+    return int(nx_str), int(ny_str)
+
+
+def summarize_history(history, benchmark, nx, ny, dt, steps):
+    final = history[-1]
+    return {
+        "benchmark": benchmark,
+        "nx": nx,
+        "ny": ny,
+        "dt": dt,
+        "requested_steps": steps,
+        "completed_steps": final["step"],
+        "final_time": final["time"],
+        "final_reason": final["reason"],
+        "phase_mass": final["phase_mass"],
+        "phi_min": final["phi_min"],
+        "phi_max": final["phi_max"],
+        "div_l2": final["div_l2"],
+        "com_y": final["com_y"],
+        "max_iterations": max(entry["iterations"] for entry in history),
+        "stable": final["reason"] >= 0 and final["step"] == steps,
+    }
+
+
+def main():
+    args = parse_args()
+    from chns import CahnHilliardNavierStokes
+
+    results = []
+
+    for mesh_spec, dt in product(args.meshes, args.dts):
+        nx, ny = parse_mesh(mesh_spec)
+        print(f"Running {args.benchmark} on {nx}x{ny} with dt={dt:g}")
+        model = CahnHilliardNavierStokes(
+            benchmark=args.benchmark,
+            nx=nx,
+            ny=ny,
+            dt=dt,
+            steps=args.steps,
+            output_every=args.output_every,
+            write_output=args.write_output,
+        )
+        history = model.run()
+        summary = summarize_history(history, args.benchmark, nx, ny, dt, args.steps)
+        results.append(summary)
+        print(
+            f"  completed_steps={summary['completed_steps']} "
+            f"stable={summary['stable']} "
+            f"phi=[{summary['phi_min']:.3e}, {summary['phi_max']:.3e}] "
+            f"div={summary['div_l2']:.3e}"
+        )
+
+    summary_path = Path(args.summary_json)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote study summary to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/chns_study.py` to run mesh/timestep sweeps for the canonical single- or two-bubble CHNS benchmark and save a JSON summary
- refactor `src/chns.py` so it can be imported by the study harness without parsing CLI flags at import time
- add `--no-output` to the canonical benchmark so local stability studies can avoid writing VTK artifacts when only diagnostics are needed

## Verification
- `python3 -m py_compile src/chns.py src/chns_study.py`
- `python3 src/chns_study.py --help`
- no simulation was executed in this branch, per current workflow request

Advances #10.