### PR TITLE
Clean up warnings in the CHNS study harness

### DIFF
--- a/src/chns.py
+++ b/src/chns.py
@@ -335,13 +335,11 @@ class CahnHilliardNavierStokes:
 
         with tqdm(
             total=total_time, desc="Time Evolution", unit="s", dynamic_ncols=True, bar_format="{l_bar}{bar}| {n:.0e}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]") as pbar:
-            t = 0.0
-
             for step in range(1, n + 1):
                 solver.solve()
                 w_.assign(w)
 
-                t += dt
+                t = step * dt
 
                 velocity_fn, _, phase_fn, _ = w.subfunctions
                 diagnostics = self.collect_diagnostics(velocity_fn, phase_fn)
@@ -372,7 +370,7 @@ class CahnHilliardNavierStokes:
                 if converged_reason < 0:
                     break
 
-                pbar.update(dt)
+                pbar.update(t - pbar.n)
                 pbar.set_postfix_str(
                     f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
                 )

--- a/src/chns_study.py
+++ b/src/chns_study.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import sys
 from itertools import product
 from pathlib import Path
 
@@ -55,6 +56,7 @@ def summarize_history(history, benchmark, nx, ny, dt, steps):
 
 def main():
     args = parse_args()
+    sys.argv = [sys.argv[0]]
     from chns import CahnHilliardNavierStokes
 
     results = []


### PR DESCRIPTION
## Summary
- strip the study harness CLI arguments before importing `src/chns.py` so PETSc does not warn about unused options
- update the canonical CHNS progress bar using exact target time values so short runs do not trigger the `tqdm` clamp warning

## Verification
- `python3 -m py_compile src/chns.py src/chns_study.py`
- `bash ./run_firedrake_container python3 src/chns_study.py --benchmark single_bubble --meshes 10x30 --dts 1e-3 --steps 2 --summary-json output/chns-study-smoke.json`

Advances #10.