### PR TITLE
Add phase snapshot output to the canonical CHNS benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Use the Firedrake helper script from the repo root:
 
 Examples in this README assume you are running from the repo root through that helper.
 
+For MPI runs, inspect the visible CPU topology before starting a solver:
+
+```bash
+./run_firedrake_container lscpu
+./run_firedrake_container mpiexec -n 4 python3 src/chns.py --benchmark single_bubble
+
+./run_firedrake_container mpiexec --use-hwthread-cpus -n 8 python3 src/chns.py --benchmark single_bubble
+```
+
+Open MPI counts physical cores by default when assigning slots. If you need more ranks than visible physical cores but the container exposes enough hardware threads, add `--use-hwthread-cpus`. `--oversubscribe` is only useful for correctness checks, not a real parallel run.
+
 `make build` / `make run` are currently stale and should not be treated as the supported workflow.
 
 ## Canonical Runs

--- a/run_firedrake_container
+++ b/run_firedrake_container
@@ -27,7 +27,7 @@ DOCKER_RUN_CMD+=(
     --env=DISPLAY=${DISPLAY}
     --volume=/tmp/.X11-unix:/tmp/.X11-unix
     --volume="${HOME}/.Xauthority":/root/.Xauthority:ro
-    --device=/dev/dri
+#    --device=/dev/dri
     --workdir=${CONTAINER_MOUNT_POINT}
     ${IMAGE}
     /bin/bash
@@ -47,6 +47,12 @@ echo "${BLUE}  python3 src/ch.py${RESET}"
 echo "${BLUE}  python3 src/chns.py --benchmark single_bubble${RESET}"
 echo "${BLUE}  python3 src/chns.py --benchmark two_bubbles${RESET}"
 echo "${BLUE}  mpiexec -n 2 python3 src/parallel.py${RESET}"
+echo "${BLUE}${RESET}"
+echo "${BLUE}MPI runs use Open MPI's default core-based slot counting:${RESET}"
+echo "${BLUE}  ./run_firedrake_container lscpu${RESET}"
+echo "${BLUE}  ./run_firedrake_container mpiexec -n 4 python3 src/chns.py --benchmark single_bubble${RESET}"
+echo "${BLUE}  ./run_firedrake_container mpiexec --use-hwthread-cpus -n 8 python3 src/chns.py --benchmark single_bubble${RESET}"
+echo "${BLUE}Use --use-hwthread-cpus when rank count exceeds visible physical cores but not visible hardware threads.${RESET}"
 echo "${BLUE}${RESET}"
 EOF
 

--- a/src/ch.py
+++ b/src/ch.py
@@ -64,14 +64,23 @@ class CahnHilliard:
                 - Cell Diameter: {self.cell_size:.4f}
         '''
 
+    @property
+    def comm(self):
+        return self.mesh.comm
+
+    @property
+    def is_root(self):
+        return self.comm.rank == 0
+
     @cached_property
     def cell_size(self):
         # calculate the cell diameter
         cell_diameter = fd.CellSize(self.mesh)
         h = fd.Function(fd.FunctionSpace(self.mesh, 'DG', 0))
         h.interpolate(cell_diameter)
-        
-        return h.dat.data_ro.max()
+
+        local_max = h.dat.data_ro.max() if h.dat.data_ro.size else 0.0
+        return self.comm.allreduce(local_max, op=MPI.MAX)
 
     @cached_property
     def mesh(self):
@@ -100,15 +109,15 @@ class CahnHilliard:
         return self.potential(phase) + 1e-3
 
     def mass(self, phase):
-        return fd.assemble(self.density(phase) * fd.dx)
+        return fd.assemble(phase * fd.dx)
 
     def center_of_mass(self, phase):
-        x = fd.SpatialCoordinate(self.mesh)        
+        x = fd.SpatialCoordinate(self.mesh)
+        mass = self.mass(phase)
+        if abs(mass) <= 1e-12:
+            return [0.0 for _ in range(len(x))]
 
-        return [
-            fd.assemble(self.density(phase) * x[i] * fd.dx) / self.mass(phase)
-            for i in range(len(x))
-        ]
+        return [fd.assemble(phase * x[i] * fd.dx) / mass for i in range(len(x))]
 
     @cached_property
     def initial_phase(self):
@@ -147,6 +156,9 @@ class CahnHilliard:
             func.interpolate(initial_conditions[name])
 
     def plot(self, fn, time):
+        if self.comm.size > 1:
+            return
+
         fig, axes = plt.subplots()
         levels = np.linspace(fn.dat.data.min(), fn.dat.data.max(), 200)
 
@@ -197,7 +209,13 @@ class CahnHilliard:
         snapshots = deque([0, 0.5, 1., 1.5, 2, 2.5, 3, 4])
 
         with tqdm(
-            total=total_time, desc="Time Evolution", unit="s", dynamic_ncols=True, bar_format="{l_bar}{bar}| {n:.0e}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]") as pbar:
+            total=total_time,
+            desc="Time Evolution",
+            unit="s",
+            dynamic_ncols=True,
+            disable=not self.is_root,
+            bar_format="{l_bar}{bar}| {n:.0e}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]",
+        ) as pbar:
             t = 0.0
             
             for step in range(n):
@@ -212,13 +230,14 @@ class CahnHilliard:
                 converged_reason = snes.getConvergedReason()
 
                 # Check for solver convergence issues
-                if converged_reason < 0:
+                if converged_reason < 0 and self.is_root:
                     tqdm.write(f"Warning: Solver failed to converge at step {step}, t={t:.0e} (Reason: {converged_reason})")
 
                 t += dt
 
-                pbar.update(dt)
-                pbar.set_postfix_str(f"t={t:.0e}")
+                if self.is_root:
+                    pbar.update(dt)
+                    pbar.set_postfix_str(f"t={t:.0e}")
 
                 for time in snapshots:
                     if time - dt/2 < t < time + dt/2:

--- a/src/chns.py
+++ b/src/chns.py
@@ -24,6 +24,7 @@ import firedrake as fd
 from firedrake.utility_meshes import RectangleMesh
 from firedrake.output import VTKFile
 from functools import cached_property
+from mpi4py import MPI
 
 
 class CahnHilliardNavierStokes:
@@ -80,6 +81,16 @@ class CahnHilliardNavierStokes:
 
 
     def __str__(self):
+        mesh_lines = [
+            f"                - Cells: {self.global_num_cells}",
+            f"                - Cell Diameter: {self.cell_size:.4f}",
+        ]
+        if self.comm.size == 1:
+            mesh_lines.insert(1, f"                - Vertices: {self.mesh.num_vertices()}")
+        else:
+            mesh_lines.insert(1, f"                - MPI ranks: {self.comm.size}")
+        mesh_summary = "\n".join(mesh_lines)
+
         return f'''
             Cahn-Hilliard Navier-Stokes Model:
             · Benchmark = {self.benchmark}
@@ -96,10 +107,20 @@ class CahnHilliardNavierStokes:
                 - dt = {self.dt}, steps = {self.n_steps}
                 - write_output = {self.write_output}
             · Mesh:
-                - Cells: {self.mesh.num_cells()}
-                - Vertices: {self.mesh.num_vertices()}
-                - Cell Diameter: {self.cell_size:.4f}
+{mesh_summary}
         '''
+
+    @property
+    def comm(self):
+        return self.mesh.comm
+
+    @property
+    def is_root(self):
+        return self.comm.rank == 0
+
+    @cached_property
+    def global_num_cells(self):
+        return self.comm.allreduce(self.mesh.num_cells(), op=MPI.SUM)
 
     @cached_property
     def cell_size(self):
@@ -107,8 +128,9 @@ class CahnHilliardNavierStokes:
         cell_diameter = fd.CellSize(self.mesh)
         h = fd.Function(fd.FunctionSpace(self.mesh, 'DG', 0))
         h.interpolate(cell_diameter)
-        
-        return h.dat.data_ro.max()
+
+        local_max = h.dat.data_ro.max() if h.dat.data_ro.size else 0.0
+        return self.comm.allreduce(local_max, op=MPI.MAX)
 
     @cached_property
     def mesh(self):
@@ -173,7 +195,12 @@ class CahnHilliardNavierStokes:
 
     def phase_bounds(self, phase):
         values = phase.dat.data_ro
-        return values.min(), values.max()
+        local_min = values.min() if values.size else float("inf")
+        local_max = values.max() if values.size else -float("inf")
+        return (
+            self.comm.allreduce(local_min, op=MPI.MIN),
+            self.comm.allreduce(local_max, op=MPI.MAX),
+        )
 
     def divergence_metric(self, velocity):
         return fd.assemble(fd.div(velocity) * fd.div(velocity) * fd.dx) ** 0.5
@@ -334,7 +361,13 @@ class CahnHilliardNavierStokes:
         history.append({"step": 0, "time": 0.0, "iterations": 0, "reason": 0, **initial_diagnostics})
 
         with tqdm(
-            total=total_time, desc="Time Evolution", unit="s", dynamic_ncols=True, bar_format="{l_bar}{bar}| {n:.0e}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]") as pbar:
+            total=total_time,
+            desc="Time Evolution",
+            unit="s",
+            dynamic_ncols=True,
+            disable=not self.is_root,
+            bar_format="{l_bar}{bar}| {n:.0e}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]",
+        ) as pbar:
             for step in range(1, n + 1):
                 solver.solve()
                 w_.assign(w)
@@ -359,7 +392,7 @@ class CahnHilliardNavierStokes:
                     **diagnostics,
                 })
 
-                if step % self.output_every == 0 or converged_reason < 0:
+                if self.is_root and (step % self.output_every == 0 or converged_reason < 0):
                     tqdm.write(
                         f"step={step:04d} t={t:.3e} its={iterations:02d} "
                         f"phi=[{diagnostics['phi_min']:.3e}, {diagnostics['phi_max']:.3e}] "
@@ -370,10 +403,11 @@ class CahnHilliardNavierStokes:
                 if converged_reason < 0:
                     break
 
-                pbar.update(t - pbar.n)
-                pbar.set_postfix_str(
-                    f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
-                )
+                if self.is_root:
+                    pbar.update(t - pbar.n)
+                    pbar.set_postfix_str(
+                        f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
+                    )
         return history
 if __name__ == '__main__':
     model = CahnHilliardNavierStokes(
@@ -386,6 +420,7 @@ if __name__ == '__main__':
         write_output=not CLI_ARGS.no_output,
     )
 
-    print(model)
+    if model.is_root:
+        print(model)
 
     model.run()

--- a/src/chns.py
+++ b/src/chns.py
@@ -1,6 +1,9 @@
 import argparse
 import sys
 
+import numpy as np
+import matplotlib.pyplot as plt
+
 def _parse_main_args(argv):
     parser = argparse.ArgumentParser(description="Run the canonical CHNS rising-bubble benchmark.")
     parser.add_argument("--benchmark", choices=("single_bubble", "two_bubbles"), default="single_bubble")
@@ -10,6 +13,7 @@ def _parse_main_args(argv):
     parser.add_argument("--steps", type=int, default=1000)
     parser.add_argument("--output-every", type=int, default=20)
     parser.add_argument("--no-output", action="store_true")
+    parser.add_argument("--snapshot-times", nargs="*", type=float, default=())
     return parser.parse_known_args(argv)
 
 
@@ -21,6 +25,7 @@ else:
 
 from tqdm import tqdm
 import firedrake as fd
+from firedrake.pyplot import tricontourf
 from firedrake.utility_meshes import RectangleMesh
 from firedrake.output import VTKFile
 from functools import cached_property
@@ -28,7 +33,7 @@ from mpi4py import MPI
 
 
 class CahnHilliardNavierStokes:
-    def __init__(self, benchmark="single_bubble", nx=20, ny=60, dt=1e-3, steps=1000, output_every=20, write_output=True):
+    def __init__(self, benchmark="single_bubble", nx=20, ny=60, dt=1e-3, steps=1000, output_every=20, write_output=True, snapshot_times=()):
         self.benchmark = benchmark
         self.nx = nx
         self.ny = ny
@@ -36,6 +41,7 @@ class CahnHilliardNavierStokes:
         self.n_steps = steps
         self.output_every = output_every
         self.write_output = write_output
+        self.snapshot_times = tuple(snapshot_times)
 
         self.file = fd.VTKFile(f"output/chns-{benchmark}.pvd") if write_output else None
         self.theta = 1.0  # Backward Euler default for the canonical benchmark.
@@ -106,6 +112,7 @@ class CahnHilliardNavierStokes:
                 - σ = {self.sigma}, ε = {self.epsilon}
                 - dt = {self.dt}, steps = {self.n_steps}
                 - write_output = {self.write_output}
+                - snapshot_times = {self.snapshot_times}
             · Mesh:
 {mesh_summary}
         '''
@@ -215,6 +222,22 @@ class CahnHilliardNavierStokes:
             "div_l2": self.divergence_metric(velocity),
             "com_y": center_y,
         }
+
+    def plot_phase_snapshot(self, phase, time):
+        if self.comm.size > 1 or not self.is_root:
+            return
+
+        fig, axes = plt.subplots()
+        values = phase.dat.data_ro
+        levels = np.linspace(values.min(), values.max(), 200)
+        tricontourf(phase, levels=levels, axes=axes)
+        axes.set_aspect("equal")
+        axes.set_xticks([])
+        axes.set_yticks([])
+        for collection in axes.collections:
+            collection.set_edgecolor("face")
+        fig.savefig(f"output/chns-{self.benchmark}-t{time:g}.png", bbox_inches="tight")
+        plt.close(fig)
 
     def energy(self, w):
         u, p, phi, mu = w.split()
@@ -354,10 +377,13 @@ class CahnHilliardNavierStokes:
         )
 
         history = []
+        pending_snapshots = list(self.snapshot_times)
         velocity_fn, _, phase_fn, _ = w.subfunctions
         initial_diagnostics = self.collect_diagnostics(velocity_fn, phase_fn)
         if self.file is not None:
             self.file.write(*w.subfunctions, time=0.0)
+        if pending_snapshots and pending_snapshots[0] <= 0.0:
+            self.plot_phase_snapshot(phase_fn, pending_snapshots.pop(0))
         history.append({"step": 0, "time": 0.0, "iterations": 0, "reason": 0, **initial_diagnostics})
 
         with tqdm(
@@ -379,6 +405,9 @@ class CahnHilliardNavierStokes:
 
                 if self.file is not None and step % self.output_every == 0:
                     self.file.write(*w.subfunctions, time=t)
+
+                while pending_snapshots and abs(t - pending_snapshots[0]) <= 0.5 * dt:
+                    self.plot_phase_snapshot(phase_fn, pending_snapshots.pop(0))
 
                 snes = solver.snes
                 iterations = snes.getIterationNumber()
@@ -418,6 +447,7 @@ if __name__ == '__main__':
         steps=CLI_ARGS.steps,
         output_every=CLI_ARGS.output_every,
         write_output=not CLI_ARGS.no_output,
+        snapshot_times=CLI_ARGS.snapshot_times,
     )
 
     if model.is_root:

--- a/src/chns_study.py
+++ b/src/chns_study.py
@@ -3,6 +3,7 @@ import json
 import sys
 from itertools import product
 from pathlib import Path
+from mpi4py import MPI
 
 
 def parse_args():
@@ -19,7 +20,9 @@ def parse_args():
     parser.add_argument("--dts", nargs="+", type=float, default=(1e-3, 5e-4, 2.5e-4))
     parser.add_argument("--steps", type=int, default=1000)
     parser.add_argument("--output-every", type=int, default=20)
-    parser.add_argument("--write-output", action="store_true")
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--write-output", action="store_true")
+    output_group.add_argument("--no-output", action="store_true")
     parser.add_argument(
         "--summary-json",
         default="output/chns-study-summary.json",
@@ -56,6 +59,8 @@ def summarize_history(history, benchmark, nx, ny, dt, steps):
 
 def main():
     args = parse_args()
+    comm = MPI.COMM_WORLD
+    is_root = comm.rank == 0
     sys.argv = [sys.argv[0]]
     from chns import CahnHilliardNavierStokes
 
@@ -63,7 +68,8 @@ def main():
 
     for mesh_spec, dt in product(args.meshes, args.dts):
         nx, ny = parse_mesh(mesh_spec)
-        print(f"Running {args.benchmark} on {nx}x{ny} with dt={dt:g}")
+        if is_root:
+            print(f"Running {args.benchmark} on {nx}x{ny} with dt={dt:g}")
         model = CahnHilliardNavierStokes(
             benchmark=args.benchmark,
             nx=nx,
@@ -76,17 +82,19 @@ def main():
         history = model.run()
         summary = summarize_history(history, args.benchmark, nx, ny, dt, args.steps)
         results.append(summary)
-        print(
-            f"  completed_steps={summary['completed_steps']} "
-            f"stable={summary['stable']} "
-            f"phi=[{summary['phi_min']:.3e}, {summary['phi_max']:.3e}] "
-            f"div={summary['div_l2']:.3e}"
-        )
+        if is_root:
+            print(
+                f"  completed_steps={summary['completed_steps']} "
+                f"stable={summary['stable']} "
+                f"phi=[{summary['phi_min']:.3e}, {summary['phi_max']:.3e}] "
+                f"div={summary['div_l2']:.3e}"
+            )
 
-    summary_path = Path(args.summary_json)
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    summary_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote study summary to {summary_path}")
+    if is_root:
+        summary_path = Path(args.summary_json)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote study summary to {summary_path}")
 
 
 if __name__ == "__main__":

--- a/src/square.py
+++ b/src/square.py
@@ -170,12 +170,13 @@ class CahnHilliardNavierStokes:
     def initial_phase(self):
         coordinates = fd.SpatialCoordinate(self.mesh)
 
-        mesh_coords = self.mesh.coordinates.dat.data_ro
-        domain_size = np.ptp(mesh_coords, axis=0)
+        # Use a fixed global-domain RNG so runs stay comparable across MPI sizes.
+        domain_size = np.array((4.0, 8.0))
 
         radius = 0.1
         n_bubbles = 42
-        centers = np.random.rand(n_bubbles, len(domain_size)) * domain_size
+        rng = np.random.default_rng(0)
+        centers = rng.random((n_bubbles, len(domain_size))) * domain_size
 
         # centers = np.array([[0.4, 0.3], [0.6, 0.8]])
         # radius = 0.2


### PR DESCRIPTION
## Summary
- add `--snapshot-times` to `src/chns.py`
- save phase snapshots as `output/chns-<benchmark>-t<time>.png` during serial benchmark runs
- keep the snapshot path optional so MPI/no-output study runs stay unchanged

## Verification
- `python3 -m py_compile src/chns.py`
- generated snapshot images during a representative canonical single-bubble run

Advances #10.