### PR TITLE
Write PDF snapshots alongside PNGs for canonical CHNS runs

### DIFF
--- a/src/chns.py
+++ b/src/chns.py
@@ -236,7 +236,9 @@ class CahnHilliardNavierStokes:
         axes.set_yticks([])
         for collection in axes.collections:
             collection.set_edgecolor("face")
-        fig.savefig(f"output/chns-{self.benchmark}-t{time:g}.png", bbox_inches="tight")
+        base_path = f"output/chns-{self.benchmark}-t{time:g}"
+        fig.savefig(f"{base_path}.png", bbox_inches="tight")
+        fig.savefig(f"{base_path}.pdf", bbox_inches="tight")
         plt.close(fig)
 
     def energy(self, w):


### PR DESCRIPTION
## Summary
- save `--snapshot-times` outputs from `src/chns.py` as both PNG and PDF
- keep the snapshot workflow otherwise unchanged so representative benchmark runs still produce easy-to-review images

## Verification
- `python3 -m py_compile src/chns.py`
- converted the existing single-bubble PNG snapshots into PDFs for immediate inspection