### PR TITLE
Add a GIF workflow for canonical CHNS benchmark visuals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/zsh
 
-.PHONY: clean build run run-gui run-ch run-chns run-chns-two run-parallel help
+.PHONY: clean build run run-gui run-ch run-chns run-chns-two run-parallel gif-chns gif-chns-two help
 
 clean:
 	@setopt nullglob; \
@@ -31,6 +31,12 @@ run-chns-two:
 run-parallel:
 	bash ./run_firedrake_container mpiexec -n 2 python3 src/parallel.py
 
+gif-chns:
+	./make_chns_gif single_bubble
+
+gif-chns-two:
+	./make_chns_gif two_bubbles
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""
@@ -42,5 +48,7 @@ help:
 	@echo "  run-chns      Run the canonical single-bubble CHNS benchmark"
 	@echo "  run-chns-two  Run the canonical two-bubble CHNS benchmark"
 	@echo "  run-parallel  Run the experimental MPI CHNS variant"
+	@echo "  gif-chns      Build a GIF from canonical single-bubble snapshots"
+	@echo "  gif-chns-two  Build a GIF from canonical two-bubble snapshots"
 	@echo "  clean         Remove LaTeX auxiliary files from output/"
 	@echo "  help          Show this help message"

--- a/make_chns_gif
+++ b/make_chns_gif
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    echo "Usage: ./make_chns_gif <benchmark> [delay] [output-file]" >&2
+    exit 1
+fi
+
+benchmark="$1"
+delay="${2:-35}"
+output_file="${3:-output/chns-${benchmark}.gif}"
+
+mapfile -t frames < <(printf '%s\n' output/chns-"${benchmark}"-t*.png | sort -V)
+
+if [[ ${#frames[@]} -eq 0 || "${frames[0]}" == "output/chns-${benchmark}-t*.png" ]]; then
+    echo "No frames found for benchmark '${benchmark}' in output/." >&2
+    exit 1
+fi
+
+convert -delay "${delay}" -loop 0 "${frames[@]}" "${output_file}"
+echo "Wrote ${output_file}"

--- a/src/chns.py
+++ b/src/chns.py
@@ -14,6 +14,7 @@ def _parse_main_args(argv):
     parser.add_argument("--output-every", type=int, default=20)
     parser.add_argument("--no-output", action="store_true")
     parser.add_argument("--snapshot-times", nargs="*", type=float, default=())
+    parser.add_argument("--snapshot-every", type=float, default=None)
     return parser.parse_known_args(argv)
 
 
@@ -440,7 +441,23 @@ class CahnHilliardNavierStokes:
                         f"t={t:.2e} phi=[{diagnostics['phi_min']:.2e}, {diagnostics['phi_max']:.2e}] com_y={diagnostics['com_y']:.2e}"
                     )
         return history
+
+
+def build_snapshot_times(total_time, explicit_times=(), every=None):
+    snapshot_times = list(explicit_times)
+    if every is not None and every > 0:
+        count = int(total_time / every)
+        snapshot_times.extend(every * step for step in range(1, count + 1))
+
+    unique_times = []
+    for time in sorted(snapshot_times):
+        if 0.0 <= time <= total_time and (not unique_times or abs(time - unique_times[-1]) > 1e-12):
+            unique_times.append(time)
+    return tuple(unique_times)
+
+
 if __name__ == '__main__':
+    total_time = CLI_ARGS.dt * CLI_ARGS.steps
     model = CahnHilliardNavierStokes(
         benchmark=CLI_ARGS.benchmark,
         nx=CLI_ARGS.nx,
@@ -449,7 +466,7 @@ if __name__ == '__main__':
         steps=CLI_ARGS.steps,
         output_every=CLI_ARGS.output_every,
         write_output=not CLI_ARGS.no_output,
-        snapshot_times=CLI_ARGS.snapshot_times,
+        snapshot_times=build_snapshot_times(total_time, CLI_ARGS.snapshot_times, CLI_ARGS.snapshot_every),
     )
 
     if model.is_root:


### PR DESCRIPTION
## Summary
- add `--snapshot-every` to `src/chns.py` so canonical runs can request evenly spaced snapshots without listing every time explicitly
- add `make_chns_gif` to assemble canonical CHNS PNG snapshots into a GIF
- add `make gif-chns` and `make gif-chns-two` convenience targets

## Verification
- `python3 -m py_compile src/chns.py`
- `bash -n make_chns_gif`
- `make help`
- generated `output/chns-two_bubbles.gif` and `output/chns-single_bubble.gif`

Closes #36