### PR TITLE
feat(visuals): add many-bubbles frame renderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/zsh
 
-.PHONY: clean build run run-gui run-ch run-chns run-chns-two run-parallel gif-chns gif-chns-two mp4-chns mp4-chns-two help
+.PHONY: clean build run run-gui run-ch run-chns run-chns-two run-parallel gif-chns gif-chns-two gif-chns-many mp4-chns mp4-chns-two help
 
 clean:
 	@setopt nullglob; \
@@ -37,6 +37,9 @@ gif-chns:
 gif-chns-two:
 	./make_chns_gif two_bubbles
 
+gif-chns-many:
+	./make_chns_gif many_bubbles
+
 mp4-chns:
 	./make_chns_mp4 single_bubble
 
@@ -56,6 +59,7 @@ help:
 	@echo "  run-parallel  Run the experimental MPI CHNS variant"
 	@echo "  gif-chns      Build a GIF from canonical single-bubble snapshots"
 	@echo "  gif-chns-two  Build a GIF from canonical two-bubble snapshots"
+	@echo "  gif-chns-many Build a GIF from canonical many-bubbles snapshots"
 	@echo "  mp4-chns      Build an MP4 from canonical single-bubble snapshots"
 	@echo "  mp4-chns-two  Build an MP4 from canonical two-bubble snapshots"
 	@echo "  clean         Remove LaTeX auxiliary files from output/"

--- a/src/render_chns_frames.py
+++ b/src/render_chns_frames.py
@@ -1,0 +1,87 @@
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from vtkmodules.util.numpy_support import vtk_to_numpy
+from vtkmodules.vtkIOXML import vtkXMLUnstructuredGridReader
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Render canonical CHNS VTK output into PNG/PDF frames.")
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--input-dir", default=None)
+    parser.add_argument("--output-prefix", default=None)
+    parser.add_argument("--field", default="phase")
+    parser.add_argument("--vmin", type=float, default=0.0)
+    parser.add_argument("--vmax", type=float, default=1.0)
+    parser.add_argument("--figsize", nargs=2, type=float, default=(3.0, 9.0), metavar=("WIDTH", "HEIGHT"))
+    parser.add_argument("--dpi", type=int, default=200)
+    return parser.parse_args()
+
+
+def load_field(vtu_path, field_name):
+    reader = vtkXMLUnstructuredGridReader()
+    reader.SetFileName(str(vtu_path))
+    reader.Update()
+    grid = reader.GetOutput()
+
+    points = vtk_to_numpy(grid.GetPoints().GetData())[:, :2]
+    values = vtk_to_numpy(grid.GetPointData().GetArray(field_name))
+
+    rounded_points = np.round(points, decimals=12)
+    _, unique_idx = np.unique(rounded_points, axis=0, return_index=True)
+    unique_idx.sort()
+    rounded_points = rounded_points[unique_idx]
+    values = values[unique_idx]
+
+    xs = np.unique(rounded_points[:, 0])
+    ys = np.unique(rounded_points[:, 1])
+    field = np.full((len(ys), len(xs)), np.nan)
+    x_index = {value: idx for idx, value in enumerate(xs)}
+    y_index = {value: idx for idx, value in enumerate(ys)}
+
+    for (x_coord, y_coord), value in zip(rounded_points, values):
+        field[y_index[y_coord], x_index[x_coord]] = value
+
+    return xs, ys, field
+
+
+def render_frame(vtu_path, field_name, output_base, vmin, vmax, figsize, dpi):
+    xs, ys, field = load_field(vtu_path, field_name)
+    levels = np.linspace(vmin, vmax, 200)
+
+    fig, axes = plt.subplots(figsize=figsize)
+    axes.contourf(xs, ys, field, levels=levels, extend="both")
+    axes.set_aspect("equal")
+    axes.set_xlim(0.0, 1.0)
+    axes.set_ylim(0.0, 3.0)
+    axes.set_xticks([])
+    axes.set_yticks([])
+    fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
+    fig.savefig(f"{output_base}.png", dpi=dpi)
+    fig.savefig(f"{output_base}.pdf", dpi=dpi)
+    plt.close(fig)
+
+
+def main():
+    args = parse_args()
+    input_dir = Path(args.input_dir or f"output/chns-{args.benchmark}")
+    output_prefix = args.output_prefix or f"output/chns-{args.benchmark}"
+
+    frames = sorted(input_dir.glob("*.vtu"))
+    if not frames:
+        raise SystemExit(f"No VTU frames found in {input_dir}")
+
+    for index, vtu_path in enumerate(frames):
+        output_base = f"{output_prefix}-t{index:04d}"
+        render_frame(vtu_path, args.field, output_base, args.vmin, args.vmax, tuple(args.figsize), args.dpi)
+        print(f"Rendered {output_base}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small VTK-to-frame renderer for canonical CHNS output using pure Python, NumPy, matplotlib, and VTK readers
- add a `make gif-chns-many` target so the many-bubbles animation can be regenerated from saved solver output
- keep the workflow separate from the solver so visuals can be rebuilt without rerunning the simulation