### PR TITLE
Use an interspersed deterministic layout for canonical many-bubbles runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/zsh
 
-.PHONY: clean build run run-gui run-ac run-ch run-chns run-chns-two run-parallel gif-chns gif-chns-two mp4-ac-circle mp4-ac-random mp4-chns mp4-chns-two help
+.PHONY: clean build run run-gui run-ac run-ch run-chns run-chns-two run-parallel gif-chns gif-chns-two gif-chns-many mp4-ac-circle mp4-ac-random mp4-chns mp4-chns-two help
 
 clean:
 	@setopt nullglob; \
@@ -46,6 +46,9 @@ mp4-ac-circle:
 mp4-ac-random:
 	./make_allen_cahn_mp4 random
 
+gif-chns-many:
+	./make_chns_gif many_bubbles
+
 mp4-chns:
 	./make_chns_mp4 single_bubble
 
@@ -68,6 +71,7 @@ help:
 	@echo "  gif-chns-two  Build a GIF from canonical two-bubble snapshots"
 	@echo "  mp4-ac-circle Build an MP4 from Allen-Cahn circle snapshots"
 	@echo "  mp4-ac-random Build an MP4 from Allen-Cahn random snapshots"
+	@echo "  gif-chns-many Build a GIF from canonical many-bubbles snapshots"
 	@echo "  mp4-chns      Build an MP4 from canonical single-bubble snapshots"
 	@echo "  mp4-chns-two  Build an MP4 from canonical two-bubble snapshots"
 	@echo "  clean         Remove LaTeX auxiliary files from output/"

--- a/src/chns.py
+++ b/src/chns.py
@@ -274,10 +274,32 @@ class CahnHilliardNavierStokes:
             radius = 0.14
             centers = ((0.5, 0.65), (0.5, 1.05))
         elif self.benchmark == "many_bubbles":
-            radius = 0.07
-            x_coords = (0.2, 0.35, 0.5, 0.65, 0.8)
-            y_coords = (0.35, 0.55, 0.75, 0.95)
-            centers = tuple((x, y) for y in y_coords for x in x_coords)
+            radius = 0.055
+            rng = np.random.default_rng(7)
+            x_min, x_max = 0.12, 0.88
+            y_min, y_max = 0.30, 1.85
+            min_distance = 2.15 * radius
+            target_count = 24
+            centers = []
+            attempts = 0
+            max_attempts = 10000
+
+            while len(centers) < target_count and attempts < max_attempts:
+                attempts += 1
+                candidate = (
+                    rng.uniform(x_min, x_max),
+                    rng.uniform(y_min, y_max),
+                )
+                if all(
+                    (candidate[0] - center_x)**2 + (candidate[1] - center_y)**2 >= min_distance**2
+                    for center_x, center_y in centers
+                ):
+                    centers.append(candidate)
+
+            if len(centers) < target_count:
+                raise RuntimeError("Failed to place deterministic many-bubble layout")
+
+            centers = tuple(centers)
         else:
             raise ValueError(f"Unsupported benchmark: {self.benchmark}")
 


### PR DESCRIPTION
## Summary
- replace the canonical `many_bubbles` row layout with a deterministic pseudo-random droplet cloud
- keep a minimum center spacing so droplets start as distinct circles instead of touching immediately
- preserve reproducibility by using a fixed RNG seed and fixed geometric bounds

## Verification
- `python3 -m py_compile src/chns.py`
- render run: `many_bubbles`, `30x90`, `dt=5e-4`, `steps=2000`, snapshots every `0.1`, producing `output/chns-many_bubbles.gif`
- numerical run: `many_bubbles`, `40x120`, `dt=5e-4`, `steps=2000`, `8` MPI ranks, summary in `output/chns-study-many_bubbles-random-8core-long.json`

Closes #44